### PR TITLE
Add 'assert' Statements for Parameter Validation

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -35,13 +35,15 @@ public class Duke {
     }
 
     /**
-     * You should have your own function to generate a response to user input.
-     * Replace this stub with your completed method.
+     * Generates a response to user input based on the provided input command.
+     *
+     * @param input The user input command to process.
+     * @return A formatted response message based on the input command.
      */
     public String getResponse(String input) {
         int taskIndex;
         String command = input;
-        StringBuilder response = new StringBuilder(); // Create a StringBuilder to accumulate responses
+        StringBuilder response = new StringBuilder();
 
         try {
             if (Parser.isBye(command)) {

--- a/src/main/java/duke/Ui.java
+++ b/src/main/java/duke/Ui.java
@@ -11,23 +11,6 @@ import java.util.ArrayList;
 public class Ui {
 
     /**
-     * A constant line separator.
-     */
-    private static final String LINE = "____________________________________________________________";
-
-    /**
-     * Displays a welcome message to the user.
-     *
-     * @return The welcome message as a string.
-     */
-    public String showWelcomeMessage() {
-        StringBuilder message = new StringBuilder();
-        message.append(" Hello! I'm Axela\n");
-        message.append(" What can I do for you?\n");
-        return message.toString();
-    }
-
-    /**
      * Displays a goodbye message to the user.
      *
      * @return The goodbye message as a string.
@@ -105,6 +88,7 @@ public class Ui {
      * @return The message as a string.
      */
     public String showTaskAdded(Task task, int totalTasks) {
+        assert task != null : "Task cannot be null";
         StringBuilder message = new StringBuilder();
         message.append(" Got it. I've added this task:\n");
         message.append("   ").append(task).append("\n");
@@ -119,6 +103,7 @@ public class Ui {
      * @return The message as a string.
      */
     public String showTaskMarkedAsDone(Task task) {
+        assert task != null : "Task cannot be null";
         StringBuilder message = new StringBuilder();
         message.append(" Nice! I've marked this task as done:\n");
         message.append("   ").append(task).append("\n");
@@ -132,6 +117,7 @@ public class Ui {
      * @return The message as a string.
      */
     public String showTaskMarkedAsNotDone(Task task) {
+        assert task != null : "Task cannot be null";
         StringBuilder message = new StringBuilder();
         message.append(" OK, I've marked this task as not done yet:\n");
         message.append("   ").append(task).append("\n");
@@ -146,6 +132,7 @@ public class Ui {
      * @return The message as a string.
      */
     public String showTaskDeleted(Task task, int totalTasks) {
+        assert task != null : "Task cannot be null";
         StringBuilder message = new StringBuilder();
         message.append(" Noted. I've removed this task:\n");
         message.append("   ").append(task).append("\n");

--- a/src/main/java/duke/command/Parser.java
+++ b/src/main/java/duke/command/Parser.java
@@ -21,6 +21,7 @@ public class Parser {
      * @return True if the command is "bye," false otherwise.
      */
     public static boolean isBye(String command) {
+        assert command != null : "Command cannot be null";
         return command.equalsIgnoreCase("bye");
     }
 
@@ -31,6 +32,7 @@ public class Parser {
      * @return True if the command is "hi," false otherwise.
      */
     public static boolean isHi(String command) {
+        assert command != null : "Command cannot be null";
         return command.equalsIgnoreCase("hi");
     }
 
@@ -41,6 +43,7 @@ public class Parser {
      * @return True if the command is "list," false otherwise.
      */
     public static boolean isList(String command) {
+        assert command != null : "Command cannot be null";
         return command.equalsIgnoreCase("list");
     }
 
@@ -51,6 +54,7 @@ public class Parser {
      * @return True if the command starts with "mark," false otherwise.
      */
     public static boolean isMarkDone(String command) {
+        assert command != null : "Command cannot be null";
         return command.startsWith("mark");
     }
 
@@ -61,6 +65,7 @@ public class Parser {
      * @return True if the command starts with "unmark," false otherwise.
      */
     public static boolean isMarkNotDone(String command) {
+        assert command != null : "Command cannot be null";
         return command.startsWith("unmark");
     }
 
@@ -71,6 +76,7 @@ public class Parser {
      * @return True if the command starts with "delete," false otherwise.
      */
     public static boolean isDelete(String command) {
+        assert command != null : "Command cannot be null";
         return command.startsWith("delete");
     }
 
@@ -82,6 +88,7 @@ public class Parser {
      * @throws DukeException If the task index cannot be extracted or is invalid.
      */
     public static int extractTaskIndex(String command) throws DukeException {
+        assert command != null : "Command cannot be null";
         String[] parts = command.split(" ");
 
         if (parts.length < 2) {
@@ -92,10 +99,12 @@ public class Parser {
     }
 
     public static boolean isFind(String command) {
+        assert command != null : "Command cannot be null";
         return command.startsWith("find");
     }
 
     public static String extractKeyword(String command) {
+        assert command != null : "Command cannot be null";
         return command.substring("find".length()).trim();
     }
 
@@ -107,6 +116,7 @@ public class Parser {
      * @throws DukeException If the command cannot be parsed or is invalid.
      */
     public static Task parseTask(String command) throws DukeException {
+        assert command != null : "Command cannot be null";
         String[] parts = command.split(" ", 2);
 
         try {
@@ -172,6 +182,7 @@ public class Parser {
      * @throws DukeException If the line cannot be parsed or is invalid.
      */
     public static Task parseFileLine(String line) throws DukeException {
+        assert line != null : "Line cannot be null";
         // Parse the line and create tasks based on the format in the file
         String[] parts = line.split(" \\| ");
 

--- a/src/main/java/duke/duke.txt
+++ b/src/main/java/duke/duke.txt
@@ -1,2 +1,3 @@
 D | 1 | feature essay (by: 2023-10-09)
 E | 0 | RVSS1002 (at: 2022-12-23)
+T | 0 | read book (from: 2019-10-15 to: 2019-10-15)

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -4,7 +4,7 @@ package duke.task;
  * The Task class represents a task template in the Duke application.
  * It includes a description and a boolean flag indicating whether the task is done or not.
  */
-public class Task {
+public abstract class Task {
     protected String description;
     protected boolean isDone;
 
@@ -75,9 +75,7 @@ public class Task {
      *
      * @return The task type as a string.
      */
-    public String getTaskType() {
-        return "";
-    }
+    public abstract String getTaskType();
 
     public String getDescription() {
         return description;

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -33,6 +33,7 @@ public class TaskList {
      * @param task The task to add.
      */
     public void addTask(Task task) {
+        assert task != null : "task cannot be null";
         this.tasks.add(task);
     }
 
@@ -130,6 +131,7 @@ public class TaskList {
     }
 
     public ArrayList<Task> findTasksByKeyword(String keyword) {
+        assert keyword != null : "keyword cannot be null";
         ArrayList<Task> matchingTasks = new ArrayList<>();
 
         for (Task task : tasks) {


### PR DESCRIPTION
Enhance code reliability by introducing 'assert' statements to validate method parameters. 'assert' statements are added at the beginning of relevant methods to ensure that critical parameters such as 'command' and 'line' are not null. This helps catch potential issues early in development, making the code more robust.

Changes Made:
- Add Javadoc header comment for getResponse function in 'Duke' class
- Add 'assert' statements in the 'Ui' class to validate 'task' parameters.
- Add 'assert' statements in the 'Parser' class to validate 'command' and 'line' parameters.
- Add 'assert' statements in the 'TaskList' class to validate 'task' and 'keyword' parameters.
- Convert 'Task' class into an abstract class

These 'assert' statements serve as a form of internal documentation, clearly indicating the expected parameter conditions and enhancing the overall maintainability of the codebase.